### PR TITLE
Correct the use of require_relative

### DIFF
--- a/lib/pay_dirt.rb
+++ b/lib/pay_dirt.rb
@@ -1,0 +1,3 @@
+require_relative 'pay_dirt/base'
+require_relative 'pay_dirt/result'
+require_relative 'pay_dirt/use_case'

--- a/lib/pay_dirt/base.rb
+++ b/lib/pay_dirt/base.rb
@@ -1,5 +1,4 @@
-require_relative "#{File.dirname(__FILE__)}/use_case.rb"
-require_relative "#{File.dirname(__FILE__)}/base.rb"
+require_relative 'use_case'
 
 
 # Here's something you can inherit from

--- a/lib/pay_dirt/result.rb
+++ b/lib/pay_dirt/result.rb
@@ -1,4 +1,3 @@
-require_relative "#{File.dirname(__FILE__)}/result.rb"
 module PayDirt
   class Result
     # The response from a use case execution

--- a/lib/pay_dirt/use_case.rb
+++ b/lib/pay_dirt/use_case.rb
@@ -1,4 +1,3 @@
-require_relative "#{File.dirname(__FILE__)}/use_case.rb"
 module PayDirt
   module UseCase
     def self.included(base)


### PR DESCRIPTION
``` ruby
require 'pay_dirt'
PayDirt.constants => [:UseCase, :Base, :Result]
```

Or if you prefer:

``` ruby
require 'pay_dirt/base'
PayDirt.constants => [:UseCase, :Base]
```

Kinda nifty, right? You can require only the bits you want.
