### PR TITLE
Feature/optional block for load options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,12 @@
 language: ruby
 
-matrix:
-  allow_failures:
-    - rvm: ree
-
-
 rvm:
-  - 2.2.1
-  - 2.1.4
+  - 2.4.0
+  - 2.3.3
+  - 2.2.6
+  - 2.1.10
   - 2.0.0
-  - 1.9.3
-  - 1.9.2
   - jruby
   - ruby-head
-  - rbx
 
 script: bundle exec rake test; bundle exec rake test # run twice to test the generator (thor scripts) via generated classes & tests

--- a/README.md
+++ b/README.md
@@ -53,16 +53,18 @@ After installing, you can use your new generator *anywhere* you can use thor. It
 ```
 $ thor help pay_dirt:service_object:new
 Usage:
-  thor pay_dirt:service_object:new FILE -d, --dependencies=one two three
+  thor pay_dirt:service_object:new FILE
 
 Options:
-  -d, --dependencies=one two three  # specify required dependencies
-  -D, [--defaults=key:value]        # specify default dependencies
-  -i, [--inherit]                   # inherit from PayDirt::Base class
-                                    # Default: true
-  -m, [--include]                   # include the PayDirt::UseCase module (overrides --inherit)
+  -d, [--dependencies=one two three]     # specify required dependencies
+      [--test-framework=TEST_FRAMEWORK]  # choose a testing framework
+  -D, [--defaults=key:value]             # Specify default dependencies
+  -V, [--validations=VALIDATIONS]        # Add validations
+  -i, [--inherit], [--no-inherit]        # inherit from PayDirt::Base class
+                                         # Default: true
+  -m, [--include], [--no-include]        # include the PayDirt::UseCase module (overrides --inherit)
 
-create a service object
+create a fully tested object (optionally, requires dependencies)
 ```
 
 example
@@ -140,6 +142,25 @@ Quick::DigitCheck.new(nose: true).call
 ```
 As you can see, we can now call `Quick::DigitCheck.new(nose: true).call`
 and expect a successful return object. Where you take it from there is up to you.
+
+### Validations
+
+Version 1.1.0 adds validations, and does so in a backward compatible way. This was accomplished by
+modifying the `#load_options` to yield a block if given, otherwise it will return the options hash
+as normal. The following shows how to validate service objects using the example from class earlier
+in this README.
+
+    def initialize(options = {})
+      options = {
+        fingers: 10,
+        toes: 10,
+      }.merge(options)
+
+      load_options(:fingers, :toes, :nose, options) do
+        raise "Oh noes!" unless @fingers == @toes
+        raise "No nose?" if !!@nose
+      end
+    end
 
 more examples
 -------------

--- a/lib/pay_dirt/use_case.rb
+++ b/lib/pay_dirt/use_case.rb
@@ -5,6 +5,7 @@ module PayDirt
     # Load instance variables from the provided hash of dependencies.
     #
     # Raises if any required dependencies (+required_options+) are missing from +options+ hash.
+    # Optionally, takes and yields a block after loading options. Use this to validate dependencies.
     #
     # @param [List<String,Symbol>]
     #   option_names list of keys representing required dependencies
@@ -19,6 +20,8 @@ module PayDirt
 
       # Load remaining options
       options.each_key  { |k| options = load_option(k, options) }
+
+      block_given? ? yield : options
     end
 
     # Returns a result object conveying success or failure (+success+)

--- a/lib/pay_dirt/version.rb
+++ b/lib/pay_dirt/version.rb
@@ -1,3 +1,3 @@
 module PayDirt
-  VERSION = "1.0.9"
+  VERSION = "1.1.0"
 end

--- a/pay_dirt.thor
+++ b/pay_dirt.thor
@@ -4,16 +4,21 @@ module PayDirt
 
     desc "new FILE", "create a fully tested object (optionally, requires dependencies)"
     method_option :dependencies,
-      type: :array,
-      aliases: "-d",
-      desc:    "specify required dependencies"
+      type:         :array,
+      aliases:      "-d",
+      desc:         "specify required dependencies"
     method_option :test_framework,
-      type: :string,
-      desc:    "choose a testing framework"
+      type:         :string,
+      desc:         "choose a testing framework"
     method_option :defaults,
-      type: :hash,
-      aliases: "-D",
-      desc: "Specify default dependencies"
+      type:         :hash,
+      aliases:      "-D",
+      desc:         "Specify default dependencies"
+    method_option :validations,
+      type:         :boolean,
+      aliases:      "-V",
+      lazy_default: true,
+      desc:         "Add validations"
     method_option :inherit,
       type:         :boolean,
       desc:         "inherit from PayDirt::Base class",
@@ -77,7 +82,15 @@ module PayDirt
       append(@inner_depth.next, "# will fail if any keys given before options aren't in options\n")
       append(@inner_depth.next, "load_options(")
       @dependencies.each { |dep| append(0, ":#{dep}, ") }
-      append(0, "options)\n")
+      append(0, "options)")
+
+      if options[:validations]
+        append(0, " do\n")
+        append(@inner_depth.next, "end\n")
+      else
+        append(0,"\n")
+      end
+
     end
 
     def set_defaults

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,5 +7,5 @@ require "minitest/autorun"
 $: << File.dirname(__FILE__) + "/../lib"
 $: << File.dirname(__FILE__)
 
-`thor pay_dirt:service_object:new quick/digit_check -d fingers toes nose -D fingers:10 toes:10`
-
+`thor pay_dirt:service_object:new quick/digit_check     -d fingers toes nose -D fingers:10 toes:10`
+`thor pay_dirt:service_object:new quick/digit_guarantee -d fingers toes nose -D fingers:10 toes:10 -V`


### PR DESCRIPTION
  - A service object should not intialize unless
    its required dependencies are supplied, yes,
    but it should also not initialize if the supplied
    dependencies are invalid.
  - Make #load_options yield a block if given, where business
    logic can be applied to validate the loaded options.
  - Just raise something if conditions are invalid
  - Fill in the validations with private method calls or inline logic
    to validate the supplied options.
  - Bumps minor version: functionality added in a backwards compatible manner.
  - Example:
```
    thor pay_dirt:service_object:new digit_validation --validations -d fingers nose
```